### PR TITLE
Wip serato 4.3.1

### DIFF
--- a/modules/juce_audio_plugin_client/AU/juce_AU_Resources.r
+++ b/modules/juce_audio_plugin_client/AU/juce_AU_Resources.r
@@ -1,0 +1,69 @@
+/*
+  ==============================================================================
+
+   This file is part of the JUCE library.
+   Copyright (c) 2015 - ROLI Ltd.
+
+   Permission is granted to use this software under the terms of either:
+   a) the GPL v2 (or any later version)
+   b) the Affero GPL v3
+
+   Details of these licenses can be found at: www.gnu.org/licenses
+
+   JUCE is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+   A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+   ------------------------------------------------------------------------------
+
+   To release a closed-source product which uses JUCE, commercial licenses are
+   available: visit www.juce.com for more information.
+
+  ==============================================================================
+*/
+
+#define UseExtendedThingResource 1
+#include <AudioUnit/AudioUnit.r>
+
+//==============================================================================
+/*  The AppConfig.h file should be a file in your project, containing info to describe the
+    plugin's name, type, etc. The introjucer will generate this file automatically for you.
+
+    You may need to adjust the include path of your project to make sure it can be 
+    found by this include statement. (Don't hack this file to change the include path)
+*/
+#include "AppConfig.h"
+
+
+//==============================================================================
+// component resources for Audio Unit
+#define RES_ID          1000
+#define COMP_TYPE       JucePlugin_AUMainType
+#define COMP_SUBTYPE    JucePlugin_AUSubType
+#define COMP_MANUF      JucePlugin_AUManufacturerCode
+#define VERSION         JucePlugin_VersionCode
+#define NAME            JucePlugin_Manufacturer ": " JucePlugin_Name
+#define DESCRIPTION     JucePlugin_Desc
+#define ENTRY_POINT     JucePlugin_AUExportPrefixQuoted "Entry"
+
+#include "AUResources.r"
+
+//==============================================================================
+// component resources for Audio Unit Carbon View
+
+#ifndef BUILD_AU_CARBON_UI
+ #define BUILD_AU_CARBON_UI 1
+#endif
+
+#if BUILD_AU_CARBON_UI
+ #define RES_ID         2000
+ #define COMP_TYPE      kAudioUnitCarbonViewComponentType
+ #define COMP_SUBTYPE   JucePlugin_AUSubType
+ #define COMP_MANUF		JucePlugin_AUManufacturerCode
+ #define VERSION        JucePlugin_VersionCode
+ #define NAME           JucePlugin_Manufacturer ": " JucePlugin_Name " View"
+ #define DESCRIPTION    NAME
+ #define ENTRY_POINT    JucePlugin_AUExportPrefixQuoted "ViewEntry"
+
+ #include "AUResources.r"
+#endif

--- a/modules/juce_audio_plugin_client/utility/juce_PluginHostType.h
+++ b/modules/juce_audio_plugin_client/utility/juce_PluginHostType.h
@@ -43,7 +43,7 @@ public:
         AdobePremierePro,
         AppleLogic,
         Ardour,
-        BitwigStudio,
+        Bitwig,
         CakewalkSonar8,
         CakewalkSonarGeneric,
         DaVinciResolve,
@@ -52,6 +52,8 @@ public:
         FinalCut,
         FruityLoops,
         MagixSamplitude,
+        Maschine2,
+        MaschineGeneric,
         MergingPyramix,
         MuseReceptorGeneric,
         Reaper,
@@ -86,7 +88,7 @@ public:
     bool isAbletonLive() const noexcept       { return type == AbletonLive6 || type == AbletonLive7 || type == AbletonLive8 || type == AbletonLiveGeneric; }
     bool isAdobeAudition() const noexcept     { return type == AdobeAudition; }
     bool isArdour() const noexcept            { return type == Ardour; }
-    bool isBitwigStudio() const noexcept      { return type == BitwigStudio; }
+	bool isBitwig() const noexcept            { return type == Bitwig; }
     bool isCubase() const noexcept            { return type == SteinbergCubase4 || type == SteinbergCubase5 || type == SteinbergCubase5Bridged || type == SteinbergCubase6 || type == SteinbergCubase7 || type == SteinbergCubase8 || type == SteinbergCubaseGeneric; }
     bool isCubase7orLater() const noexcept    { return isCubase() && ! (type == SteinbergCubase4 || type == SteinbergCubase5 || type == SteinbergCubase6); }
     bool isCubaseBridged() const noexcept     { return type == SteinbergCubase5Bridged; }
@@ -95,6 +97,8 @@ public:
     bool isFinalCut() const noexcept          { return type == FinalCut; }
     bool isFruityLoops() const noexcept       { return type == FruityLoops; }
     bool isLogic() const noexcept             { return type == AppleLogic; }
+	bool isMaschine2() const noexcept         { return type == Maschine2; }
+	bool isMaschineGeneric() const noexcept   { return type == MaschineGeneric; }
     bool isNuendo() const noexcept            { return type == SteinbergNuendo3 || type == SteinbergNuendo4  || type == SteinbergNuendo5 ||  type == SteinbergNuendoGeneric; }
     bool isPremiere() const noexcept          { return type == AdobePremierePro; }
     bool isProTools() const noexcept          { return type == DigidesignProTools; }
@@ -125,7 +129,8 @@ public:
             case AdobeAudition:            return "Adobe Audition";
             case AdobePremierePro:         return "Adobe Premiere";
             case AppleLogic:               return "Apple Logic";
-            case BitwigStudio:             return "Bitwig Studio";
+            case Ardour:                   return "Ardour";
+            case Bitwig:                   return "Bitwig";
             case CakewalkSonar8:           return "Cakewalk Sonar 8";
             case CakewalkSonarGeneric:     return "Cakewalk Sonar";
             case DaVinciResolve:           return "DaVinci Resolve";
@@ -134,6 +139,8 @@ public:
             case FinalCut:                 return "Final Cut";
             case FruityLoops:              return "FruityLoops";
             case MagixSamplitude:          return "Magix Samplitude";
+            case Maschine2:                return "Maschine 2";
+            case MaschineGeneric:          return "Maschine";
             case MergingPyramix:           return "Pyramix";
             case MuseReceptorGeneric:      return "Muse Receptor";
             case Reaper:                   return "Reaper";
@@ -205,7 +212,10 @@ private:
         if (hostFilename.containsIgnoreCase ("Live"))              return AbletonLiveGeneric;
         if (hostFilename.containsIgnoreCase ("Adobe Premiere"))    return AdobePremierePro;
         if (hostFilename.contains           ("Logic"))             return AppleLogic;
+		if (hostFilename.contains           ("Bitwig"))            return Bitwig;
         if (hostFilename.containsIgnoreCase ("Pro Tools"))         return DigidesignProTools;
+		if (hostFilename.containsIgnoreCase ("Maschine 2"))        return Maschine2;
+		if (hostFilename.containsIgnoreCase ("Maschine"))          return MaschineGeneric;
         if (hostFilename.containsIgnoreCase ("Nuendo 3"))          return SteinbergNuendo3;
         if (hostFilename.containsIgnoreCase ("Nuendo 4"))          return SteinbergNuendo4;
         if (hostFilename.containsIgnoreCase ("Nuendo 5"))          return SteinbergNuendo5;
@@ -227,7 +237,6 @@ private:
         if (hostFilename.containsIgnoreCase ("Tracktion"))         return TracktionGeneric;
         if (hostFilename.containsIgnoreCase ("Renoise"))           return Renoise;
         if (hostFilename.containsIgnoreCase ("Resolve"))           return DaVinciResolve;
-        if (hostFilename.startsWith         ("Bitwig"))            return BitwigStudio;
 
        #elif JUCE_WINDOWS
         if (hostFilename.containsIgnoreCase ("Live 6."))           return AbletonLive6;
@@ -236,7 +245,10 @@ private:
         if (hostFilename.containsIgnoreCase ("Live "))             return AbletonLiveGeneric;
         if (hostFilename.containsIgnoreCase ("Audition"))          return AdobeAudition;
         if (hostFilename.containsIgnoreCase ("Adobe Premiere"))    return AdobePremierePro;
+		if (hostFilename.contains           ("Bitwig"))            return Bitwig;
         if (hostFilename.containsIgnoreCase ("ProTools"))          return DigidesignProTools;
+		if (hostFilename.containsIgnoreCase ("Maschine 2"))        return Maschine2;
+		if (hostFilename.containsIgnoreCase ("Maschine"))          return MaschineGeneric;
         if (hostPath.containsIgnoreCase     ("SONAR 8"))           return CakewalkSonar8;
         if (hostFilename.containsIgnoreCase ("SONAR"))             return CakewalkSonarGeneric;
         if (hostFilename.containsIgnoreCase ("Logic"))             return AppleLogic;
@@ -267,12 +279,9 @@ private:
         if (hostFilename.startsWithIgnoreCase ("Sam"))             return MagixSamplitude;
         if (hostFilename.containsIgnoreCase ("Renoise"))           return Renoise;
         if (hostFilename.containsIgnoreCase ("Resolve"))           return DaVinciResolve;
-        if (hostPath.containsIgnoreCase     ("Bitwig Studio"))     return BitwigStudio;
 
        #elif JUCE_LINUX
         if (hostFilename.containsIgnoreCase ("Ardour"))            return Ardour;
-        if (hostFilename.startsWith         ("Bitwig"))            return BitwigStudio;
-
        #elif JUCE_IOS
        #else
         #error

--- a/modules/juce_audio_plugin_client/utility/juce_PluginHostType.h
+++ b/modules/juce_audio_plugin_client/utility/juce_PluginHostType.h
@@ -51,6 +51,7 @@ public:
         DigitalPerformer,
         FinalCut,
         FruityLoops,
+		GarageBand,
         MagixSamplitude,
         Maschine2,
         MaschineGeneric,
@@ -96,6 +97,7 @@ public:
     bool isDigitalPerformer() const noexcept  { return type == DigitalPerformer; }
     bool isFinalCut() const noexcept          { return type == FinalCut; }
     bool isFruityLoops() const noexcept       { return type == FruityLoops; }
+	bool isGarageBand() const noexcept        { return type == GarageBand; }
     bool isLogic() const noexcept             { return type == AppleLogic; }
 	bool isMaschine2() const noexcept         { return type == Maschine2; }
 	bool isMaschineGeneric() const noexcept   { return type == MaschineGeneric; }
@@ -138,6 +140,7 @@ public:
             case DigitalPerformer:         return "DigitalPerformer";
             case FinalCut:                 return "Final Cut";
             case FruityLoops:              return "FruityLoops";
+			case GarageBand:			   return "GarageBand";
             case MagixSamplitude:          return "Magix Samplitude";
             case Maschine2:                return "Maschine 2";
             case MaschineGeneric:          return "Maschine";
@@ -214,6 +217,8 @@ private:
         if (hostFilename.contains           ("Logic"))             return AppleLogic;
 		if (hostFilename.contains           ("Bitwig"))            return Bitwig;
         if (hostFilename.containsIgnoreCase ("Pro Tools"))         return DigidesignProTools;
+		if (hostFilename.startsWith         ("OsxFL"))             return FruityLoops;
+		if (hostFilename.containsIgnoreCase ("GarageBand"))        return GarageBand;
 		if (hostFilename.containsIgnoreCase ("Maschine 2"))        return Maschine2;
 		if (hostFilename.containsIgnoreCase ("Maschine"))          return MaschineGeneric;
         if (hostFilename.containsIgnoreCase ("Nuendo 3"))          return SteinbergNuendo3;

--- a/modules/juce_audio_plugin_client/utility/juce_WindowsHooks.h
+++ b/modules/juce_audio_plugin_client/utility/juce_WindowsHooks.h
@@ -41,13 +41,18 @@ namespace
         {
             if (numHookUsers++ == 0)
             {
+#ifndef SERATO_JUCE_DISABLE_HOOKS
+                // [CUD-612] These hooks are a JUCE workaround to handle mouse wheel/keyboard events on Windows, and they are conflicting
+                // with the hooks used by QT, since they are not calling the next hook in the chain in those cases. If we leave these hooks
+                // in the chain and properly call the next one, it introduces a significant overhead, so instead we are removing it.
                 mouseWheelHook = SetWindowsHookEx (WH_MOUSE, mouseWheelHookCallback,
                                                    (HINSTANCE) Process::getCurrentModuleInstanceHandle(),
                                                    GetCurrentThreadId());
-
+                // Keyboard hooks were disabled for Cuddlefish as part of [CUD-1125]
                 keyboardHook = SetWindowsHookEx (WH_GETMESSAGE, keyboardHookCallback,
                                                  (HINSTANCE) Process::getCurrentModuleInstanceHandle(),
                                                  GetCurrentThreadId());
+#endif
             }
         }
 


### PR DESCRIPTION
Forked Juce 4.3.1 and cherry picked commits we made to 4.2.3. Updating due to CUD-1250 in which we're splitting Samples output across multiple channels. In 4.3.1, a number of changes were made to how Juce supports multi-channel input and output. Therefore, it's been decided to update before going ahead with the story.